### PR TITLE
Added check for the /.ssh/ folder in tunnel-ssh-client.

### DIFF
--- a/roles/tunnel-ssh-client/tasks/tunnel-ssh-service.yml
+++ b/roles/tunnel-ssh-client/tasks/tunnel-ssh-service.yml
@@ -2,6 +2,11 @@
 # Date: 2017-05-22
 # Description: Creates an AutoSSH service that tunnels back to the IP specified in the service config. Thanks to https://www.everythingcli.org/ssh-tunnelling-for-fun-and-profit-autossh/
 ---
+- file:
+    path: "{{ ansible_env.HOME }}/.ssh"
+    state: directory
+    mode: 0755
+
 - name: "Create ssh config"
   blockinfile:
     create: yes


### PR DESCRIPTION
Creates the folder if it doesn't exist.  Should fix Ansible falling over if the folder doesn't exist.